### PR TITLE
Use API introduced in kernel 4.8.0, if available

### DIFF
--- a/Using-PCIe-Interrupts/f1_driver.c
+++ b/Using-PCIe-Interrupts/f1_driver.c
@@ -36,6 +36,7 @@
 #include <linux/stat.h>
 #include <linux/uaccess.h>
 #include <linux/pci.h>
+#include <linux/version.h>
 
 #include <linux/slab.h>
 #include <linux/interrupt.h>
@@ -152,7 +153,12 @@ static int __init f1_init(void) {
   *(unsigned int *)ddr_base = 0x0;
   
   // allocate MSIX resources
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,8,0)
+  result = pci_enable_msix_exact(f1_dev, f1_ints, NUM_OF_USER_INTS);
+#else
   result = pci_enable_msix(f1_dev, f1_ints, NUM_OF_USER_INTS);
+#endif
 
   // initialize user interrupts with interrupt specific data
   for(i=0; i<NUM_OF_USER_INTS; i++) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
`pci_enable_msix` (and others) are deprecated as of kernel 4.8 and removed in kernel 4.12. The provided example does not work with the Ubuntu 18.04 AMI, as it comes with kernel 4.15. This PR fixes the example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
